### PR TITLE
Show feeds in search fragment

### DIFF
--- a/app/src/main/java/com/guardian/podxdemo/presentation/MainActivity.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/MainActivity.kt
@@ -11,6 +11,11 @@ import dagger.android.HasAndroidInjector
 import timber.log.Timber
 import javax.inject.Inject
 
+/**
+ * A simple activity who's layout contains the navigation component responsible for displaying the
+ * UI.
+ */
+
 class MainActivity : AppCompatActivity(), HasAndroidInjector {
     @Inject
     lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Any>
@@ -19,9 +24,9 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
     lateinit var fragmentInjectionFactory: FragmentInjectionFactory
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Timber.i("Creating main activity")
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
-        Timber.i("Creating main activity")
         supportFragmentManager.fragmentFactory = fragmentInjectionFactory
         setContentView(R.layout.layout_mainactivity)
     }

--- a/app/src/main/java/com/guardian/podxdemo/presentation/common/DataBoundListAdapter.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/common/DataBoundListAdapter.kt
@@ -1,0 +1,32 @@
+package com.guardian.podxdemo.presentation.common
+
+import android.view.ViewGroup
+import androidx.databinding.ViewDataBinding
+import androidx.recyclerview.widget.AsyncDifferConfig
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+
+abstract class DataBoundListAdapter<T, V : ViewDataBinding> (
+    callback: DiffUtil.ItemCallback<T>
+) : ListAdapter<T, DataBoundListAdapter.DataBoundViewHolder<V>>(
+    AsyncDifferConfig.Builder<T>(callback)
+        .build()
+) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DataBoundViewHolder<V> {
+        return DataBoundViewHolder(
+            createBinding(parent)
+        )
+    }
+
+    abstract fun createBinding(parent: ViewGroup): V
+
+    override fun onBindViewHolder(holder: DataBoundViewHolder<V>, position: Int) {
+        bind(holder.binding , getItem(position))
+    }
+
+    abstract fun bind(holder: V, item: T)
+
+    class DataBoundViewHolder<out T : ViewDataBinding> constructor(val binding: T) :
+        RecyclerView.ViewHolder(binding.root)
+}

--- a/app/src/main/java/com/guardian/podxdemo/presentation/common/HideKeyboard.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/common/HideKeyboard.kt
@@ -1,0 +1,11 @@
+package com.guardian.podxdemo.presentation.common
+
+import android.app.Activity
+import android.view.inputmethod.InputMethodManager
+import androidx.fragment.app.Fragment
+
+fun Fragment.hideKeyboard() {
+    (activity?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager).apply {
+        this.hideSoftInputFromWindow(view?.rootView?.windowToken, 0)
+    }
+}

--- a/app/src/main/java/com/guardian/podxdemo/presentation/common/HideKeyboard.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/common/HideKeyboard.kt
@@ -3,9 +3,14 @@ package com.guardian.podxdemo.presentation.common
 import android.app.Activity
 import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
+import timber.log.Timber
 
 fun Fragment.hideKeyboard() {
-    (activity?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager).apply {
-        this.hideSoftInputFromWindow(view?.rootView?.windowToken, 0)
+    try {
+        (requireActivity().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager).apply {
+            this.hideSoftInputFromWindow(requireView().rootView.windowToken, 0)
+        }
+    } catch (e: IllegalStateException) {
+        Timber.e(e)
     }
 }

--- a/app/src/main/java/com/guardian/podxdemo/presentation/common/binding/ImageBindingAdapter.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/common/binding/ImageBindingAdapter.kt
@@ -4,7 +4,7 @@ import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
 
-@BindingAdapter("bind:imageUrl")
+@BindingAdapter("imageUrl")
 fun bindImageUrlString(imageView: ImageView, imageUrlString: String) {
     Glide.with(imageView.context).load(imageUrlString).into(imageView)
 }

--- a/app/src/main/java/com/guardian/podxdemo/presentation/common/binding/ImageBindingAdapter.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/common/binding/ImageBindingAdapter.kt
@@ -1,4 +1,4 @@
-package com.guardian.podxdemo.utils.binding
+package com.guardian.podxdemo.presentation.common.binding
 
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter

--- a/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchFragment.kt
@@ -50,24 +50,28 @@ class SearchFragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.lifecycleOwner = viewLifecycleOwner
-        binding.searchViewModel = searchViewModel
+
         setupRecyclerView()
         setupEditText()
+
+        if (savedInstanceState == null) {
+            binding.search = getString(R.string.searchfragment_default_term)
+            searchViewModel.doSearch(getString(R.string.searchfragment_default_term))
+        }
     }
 
     private fun setupEditText() {
         binding.edittextSearchTerm.setOnEditorActionListener { _, eventId, _ ->
-            Timber.i("got editor action")
             if (eventId == EditorInfo.IME_ACTION_DONE) {
-                Timber.i("got done action")
-                searchViewModel.doSearch()
+                val searchTerm: String = binding.search
+                    ?: getString(R.string.searchfragment_default_term)
+                searchViewModel.doSearch(searchTerm)
                 hideKeyboard()
+
             }
 
             true
         }
-
-        searchViewModel.doSearch()
     }
 
     private fun setupRecyclerView() {
@@ -90,7 +94,7 @@ class SearchFragment
                 }
             }
         ).apply {
-            searchViewModel.searchResults
+            searchViewModel.uiModel.results
                 .observe(viewLifecycleOwner, Observer { results ->
                     this.submitList(results)
                     Timber.i("${this.itemCount} SearchResults added")

--- a/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchFragment.kt
@@ -5,19 +5,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
-import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.GridLayoutManager
-import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
-import com.guardian.podxdemo.databinding.LayoutSearchfragmentBinding
-import com.guardian.podxdemo.databinding.ViewholderSearchadapterResultBinding
 import com.guardian.core.search.SearchResult
 import com.guardian.podxdemo.R
+import com.guardian.podxdemo.databinding.LayoutSearchfragmentBinding
 import com.guardian.podxdemo.utils.lifecycleAwareLazy
 import timber.log.Timber
 import javax.inject.Inject
@@ -50,8 +46,24 @@ class SearchFragment
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.lifecycleOwner = viewLifecycleOwner
         binding.recyclerviewSearchResults.layoutManager = GridLayoutManager(context, 2)
-        binding.recyclerviewSearchResults.adapter = SearchAdapter()
-            .apply {
+
+        binding.recyclerviewSearchResults.adapter = SearchListAdapter(
+            callback = object : DiffUtil.ItemCallback<SearchResult>() {
+                override fun areItemsTheSame(
+                    oldItem: SearchResult,
+                    newItem: SearchResult
+                ): Boolean {
+                    return oldItem == newItem
+                }
+
+                override fun areContentsTheSame(
+                    oldItem: SearchResult,
+                    newItem: SearchResult
+                ): Boolean {
+                    return oldItem.feedUrlString == newItem.feedUrlString
+                }
+            }
+        ).apply {
                 searchViewModel.searchResults
                     .observe(viewLifecycleOwner, Observer { results ->
                         this.submitList(results)
@@ -61,35 +73,3 @@ class SearchFragment
     }
 }
 
-class SearchAdapter
-    : ListAdapter<SearchResult, SearchAdapter.DataBoundViewHolder<ViewholderSearchadapterResultBinding>>
-    (object
-    : DiffUtil.ItemCallback<SearchResult>() {
-    override fun areItemsTheSame(oldItem: SearchResult, newItem: SearchResult): Boolean {
-        return oldItem === newItem
-    }
-
-    override fun areContentsTheSame(oldItem: SearchResult, newItem: SearchResult): Boolean {
-        return oldItem.feedUrlString == newItem.feedUrlString
-    }
-
-}) {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DataBoundViewHolder<ViewholderSearchadapterResultBinding> {
-        val binding = DataBindingUtil.inflate<ViewholderSearchadapterResultBinding>(
-            LayoutInflater.from(parent.context),
-            R.layout.viewholder_searchadapter_result,
-            parent,
-            false
-        )
-        Timber.i("Creating ViewHolder")
-        return DataBoundViewHolder(binding)
-    }
-
-    override fun onBindViewHolder(holder: DataBoundViewHolder<ViewholderSearchadapterResultBinding>, position: Int) {
-        holder.binding.searchResult = getItem(position)
-        Timber.i("${getItem(position).title} being bound")
-    }
-
-    class DataBoundViewHolder<out T : ViewDataBinding> constructor(val binding: T) :
-        RecyclerView.ViewHolder(binding.root)
-}

--- a/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchFragment.kt
@@ -15,8 +15,8 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.guardian.core.search.SearchResult
 import com.guardian.podxdemo.R
 import com.guardian.podxdemo.databinding.LayoutSearchfragmentBinding
+import com.guardian.podxdemo.presentation.common.hideKeyboard
 import com.guardian.podxdemo.utils.lifecycleAwareLazy
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -61,6 +61,7 @@ class SearchFragment
             if (eventId == EditorInfo.IME_ACTION_DONE) {
                 Timber.i("got done action")
                 searchViewModel.doSearch()
+                hideKeyboard()
             }
 
             true

--- a/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -15,8 +16,13 @@ import com.guardian.core.search.SearchResult
 import com.guardian.podxdemo.R
 import com.guardian.podxdemo.databinding.LayoutSearchfragmentBinding
 import com.guardian.podxdemo.utils.lifecycleAwareLazy
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import javax.inject.Inject
+
+/**
+ * The UI for lists of podcast feeds
+ */
 
 class SearchFragment
     @Inject constructor(viewModelProviderFactory: ViewModelProvider.Factory)
@@ -25,7 +31,6 @@ class SearchFragment
     private val searchViewModel: SearchViewModel by viewModels {
         viewModelProviderFactory
     }
-
     private var binding: LayoutSearchfragmentBinding by lifecycleAwareLazy()
 
     override fun onCreateView(
@@ -45,6 +50,26 @@ class SearchFragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.lifecycleOwner = viewLifecycleOwner
+        binding.searchViewModel = searchViewModel
+        setupRecyclerView()
+        setupEditText()
+    }
+
+    private fun setupEditText() {
+        binding.edittextSearchTerm.setOnEditorActionListener { _, eventId, _ ->
+            Timber.i("got editor action")
+            if (eventId == EditorInfo.IME_ACTION_DONE) {
+                Timber.i("got done action")
+                searchViewModel.doSearch()
+            }
+
+            true
+        }
+
+        searchViewModel.doSearch()
+    }
+
+    private fun setupRecyclerView() {
         binding.recyclerviewSearchResults.layoutManager = GridLayoutManager(context, 2)
 
         binding.recyclerviewSearchResults.adapter = SearchListAdapter(
@@ -64,12 +89,12 @@ class SearchFragment
                 }
             }
         ).apply {
-                searchViewModel.searchResults
-                    .observe(viewLifecycleOwner, Observer { results ->
-                        this.submitList(results)
-                        Timber.i("${this.itemCount} SearchResults added")
-                    })
-            }
+            searchViewModel.searchResults
+                .observe(viewLifecycleOwner, Observer { results ->
+                    this.submitList(results)
+                    Timber.i("${this.itemCount} SearchResults added")
+                })
+        }
     }
 }
 

--- a/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchListAdapter.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchListAdapter.kt
@@ -1,0 +1,26 @@
+package com.guardian.podxdemo.presentation.search
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.DiffUtil
+import com.guardian.core.search.SearchResult
+import com.guardian.podxdemo.R
+import com.guardian.podxdemo.databinding.ViewholderSearchadapterResultBinding
+import com.guardian.podxdemo.presentation.common.DataBoundListAdapter
+
+class SearchListAdapter(callback: DiffUtil.ItemCallback<SearchResult>) :
+    DataBoundListAdapter<SearchResult, ViewholderSearchadapterResultBinding>(callback) {
+    override fun createBinding(parent: ViewGroup): ViewholderSearchadapterResultBinding {
+        return DataBindingUtil.inflate(
+            LayoutInflater.from(parent.context),
+            R.layout.viewholder_searchadapter_result,
+            parent,
+            false
+        )
+    }
+
+    override fun bind(holder: ViewholderSearchadapterResultBinding, item: SearchResult) {
+        holder.searchResult = item
+    }
+}

--- a/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchViewModel.kt
@@ -11,6 +11,8 @@ class SearchViewModel
 @Inject constructor(searchRepository: SearchRepository)
     : ViewModel() {
     val searchResults: LiveData<List<SearchResult>> = liveData {
-        emit(searchRepository.doSearch("news"))
+        emit(searchRepository.doSearch(searchString))
     }
+
+    var searchString = "news"
 }

--- a/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchViewModel.kt
@@ -1,22 +1,31 @@
 package com.guardian.podxdemo.presentation.search
 
-import androidx.databinding.Bindable
-import androidx.databinding.ObservableField
-import androidx.lifecycle.*
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.guardian.core.search.SearchRepository
 import com.guardian.core.search.SearchResult
-import kotlinx.coroutines.*
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class SearchViewModel
-@Inject constructor(val searchRepository: SearchRepository)
+@Inject constructor(private val searchRepository: SearchRepository)
     : ViewModel() {
 
-    val searchResults: MutableLiveData<List<SearchResult>> = MutableLiveData()
+    private val searchResults: MutableLiveData<List<SearchResult>> = MutableLiveData()
 
-    var searchString = "news"
+    val uiModel: SearchUiModel by lazy {
+        SearchUiModel(
+            searchResults
+        )
+    }
 
-    fun doSearch () = viewModelScope.launch{
-        searchResults.postValue(searchRepository.doSearch(searchString))
+    fun doSearch (search: String) = viewModelScope.launch{
+        searchResults.postValue(searchRepository.doSearch(search))
     }
 }
+
+data class SearchUiModel(
+    val results: LiveData<List<SearchResult>>
+)

--- a/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/guardian/podxdemo/presentation/search/SearchViewModel.kt
@@ -1,18 +1,22 @@
 package com.guardian.podxdemo.presentation.search
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.liveData
+import androidx.databinding.Bindable
+import androidx.databinding.ObservableField
+import androidx.lifecycle.*
 import com.guardian.core.search.SearchRepository
 import com.guardian.core.search.SearchResult
+import kotlinx.coroutines.*
 import javax.inject.Inject
 
 class SearchViewModel
-@Inject constructor(searchRepository: SearchRepository)
+@Inject constructor(val searchRepository: SearchRepository)
     : ViewModel() {
-    val searchResults: LiveData<List<SearchResult>> = liveData {
-        emit(searchRepository.doSearch(searchString))
-    }
+
+    val searchResults: MutableLiveData<List<SearchResult>> = MutableLiveData()
 
     var searchString = "news"
+
+    fun doSearch () = viewModelScope.launch{
+        searchResults.postValue(searchRepository.doSearch(searchString))
+    }
 }

--- a/app/src/main/java/com/guardian/podxdemo/utils/LifecycleAwareLazy.kt
+++ b/app/src/main/java/com/guardian/podxdemo/utils/LifecycleAwareLazy.kt
@@ -13,24 +13,24 @@ import kotlin.reflect.KProperty
  * Accessing this variable in a destroyed fragment will throw NPE.
  */
 class LifecycleAwareLazy <T : Any>(val fragment: Fragment) : ReadWriteProperty<Fragment, T> {
-    private var _value: T? = null
+    private var value: T? = null
 
     init {
         fragment.lifecycle.addObserver(object : LifecycleObserver {
             @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
             fun onDestroy() {
-                _value = null
+                value = null
             }
         })
     }
 
     override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
-        return _value ?: throw IllegalStateException(
+        return value ?: throw IllegalStateException(
         )
     }
 
     override fun setValue(thisRef: Fragment, property: KProperty<*>, value: T) {
-        _value = value
+        this.value = value
     }
 }
 

--- a/app/src/main/res/layout/layout_searchfragment.xml
+++ b/app/src/main/res/layout/layout_searchfragment.xml
@@ -5,8 +5,8 @@
 
     <data>
         <variable
-            name="searchViewModel"
-            type="com.guardian.podxdemo.presentation.search.SearchViewModel" />
+            name="search"
+            type="String"/>
     </data>
 
 
@@ -41,7 +41,7 @@
                         android:importantForAutofill="no"
                         android:layout_marginStart="10dp"
                         android:layout_marginEnd="10dp"
-                        android:text="@={searchViewModel.searchString}" />
+                        android:text="@={search}" />
                 </LinearLayout>
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>

--- a/app/src/main/res/layout/layout_searchfragment.xml
+++ b/app/src/main/res/layout/layout_searchfragment.xml
@@ -54,7 +54,7 @@
             android:layout_height="match_parent"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
-            tools:listitem="@layout/viewholder_searchadapter_result" />
+            tools:listitem="@layout/viewholder_searchadapter_result"/>
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/layout_searchfragment.xml
+++ b/app/src/main/res/layout/layout_searchfragment.xml
@@ -41,7 +41,7 @@
                         android:importantForAutofill="no"
                         android:layout_marginStart="10dp"
                         android:layout_marginEnd="10dp"
-                        android:text=""/>
+                        android:text="@={searchViewModel.searchString}" />
                 </LinearLayout>
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>

--- a/app/src/main/res/layout/layout_searchfragment.xml
+++ b/app/src/main/res/layout/layout_searchfragment.xml
@@ -1,17 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:tools="http://schemas.android.com/tools"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+    <data>
+        <variable
+            name="searchViewModel"
+            type="com.guardian.podxdemo.presentation.search.SearchViewModel" />
+    </data>
+
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_scrollFlags="scroll|enterAlways">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+                    <Toolbar
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:title="@string/app_name"/>
+
+                    <EditText
+                        android:id="@+id/edittext_search_term"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/search"
+                        android:inputType="textFilter"
+                        android:importantForAutofill="no"
+                        android:layout_marginStart="10dp"
+                        android:layout_marginEnd="10dp"
+                        android:text=""/>
+                </LinearLayout>
+
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
+        </com.google.android.material.appbar.AppBarLayout>
+
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerview_search_results"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            tools:listitem="@layout/viewholder_searchadapter_result"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"/>
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+            tools:listitem="@layout/viewholder_searchadapter_result" />
 
-    </FrameLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/viewholder_searchadapter_result.xml
+++ b/app/src/main/res/layout/viewholder_searchadapter_result.xml
@@ -12,7 +12,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="10dp">
+        android:padding="10dp"
+        android:animateLayoutChanges="true">
         <ImageView
             android:id="@+id/imageview_search"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/viewholder_searchadapter_result.xml
+++ b/app/src/main/res/layout/viewholder_searchadapter_result.xml
@@ -29,7 +29,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@{searchResult.title}"
-            tools:text="Podex Podcast"
-            />
+            tools:text="PodX Podcast"
+            android:maxLines="4"
+            android:ellipsize="end"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#008577</color>
-    <color name="colorPrimaryDark">#00574B</color>
-    <color name="colorAccent">#D81B60</color>
+    <color name="primaryColor">#ffa000</color>
+    <color name="primaryLightColor">#ffd149</color>
+    <color name="primaryDarkColor">#c67100</color>
+    <color name="primaryTextColor">#000000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="title_feedrepository">Feed Repository</string>
     <string name="title_database">Local Database</string>
     <string name="title_podcastplayer">Podcast Player</string>
+    <string name="search">search</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="title_database">Local Database</string>
     <string name="title_podcastplayer">Podcast Player</string>
     <string name="search">search</string>
+    <string name="searchfragment_default_term">guardian</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,12 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorPrimary">@color/primaryColor</item>
+        <item name="colorPrimaryDark">@color/primaryDarkColor</item>
+        <item name="colorAccent">@color/primaryLightColor</item>
+        <item name="android:textColorPrimary">@color/primaryTextColor</item>
     </style>
 
 </resources>

--- a/core/src/main/java/com/guardian/core/search/SearchRepositoryImpl.kt
+++ b/core/src/main/java/com/guardian/core/search/SearchRepositoryImpl.kt
@@ -8,11 +8,14 @@ class SearchRepositoryImpl
 @Inject constructor(val itunesSearchApi: ItunesSearchApi)
     : SearchRepository {
     override suspend fun doSearch(term: String): List<SearchResult> {
-        return itunesSearchApi.search(term).awaitResponse().body()?.results?.map {
+        return itunesSearchApi.search(term).awaitResponse().body()?.results?.filter {
+            it.feedUrlString != null && it.feedUrlString.isNotEmpty()
+            //todo filter invalid feed urls out
+        } ?.map {
             SearchResult(
-                it.name,
-                it.atworkUrl600String,
-                it.feedUrlString
+                it.name ?: "",
+                it.atworkUrl600String ?: "",
+                it.feedUrlString ?: ""
             )
         } ?: listOf()
     }

--- a/core/src/main/java/com/guardian/core/search/SearchRepositoryImpl.kt
+++ b/core/src/main/java/com/guardian/core/search/SearchRepositoryImpl.kt
@@ -11,7 +11,7 @@ class SearchRepositoryImpl
         return itunesSearchApi.search(term).awaitResponse().body()?.results?.map {
             SearchResult(
                 it.name,
-                it.atworkUrl100String,
+                it.atworkUrl600String,
                 it.feedUrlString
             )
         } ?: listOf()

--- a/core/src/main/java/com/guardian/core/search/SearchResult.kt
+++ b/core/src/main/java/com/guardian/core/search/SearchResult.kt
@@ -1,5 +1,10 @@
 package com.guardian.core.search
 
+/**
+ * The data class that represents the result from an api that returns information about a podcast
+ * feed.
+ */
+
 data class SearchResult (
     val title : String,
     val imageUrlString : String,

--- a/core/src/main/java/com/guardian/core/search/api/SearchItunesApiDataObject.kt
+++ b/core/src/main/java/com/guardian/core/search/api/SearchItunesApiDataObject.kt
@@ -3,10 +3,10 @@ package com.guardian.core.search.api
 import com.google.gson.annotations.SerializedName
 
 data class SearchItunesApiDataObject (
-    @SerializedName("collectionName") val name: String,
-    @SerializedName("feedUrl") val feedUrlString: String,
-    @SerializedName("artworkUrl30") val atworkUrl30String: String,
-    @SerializedName("artworkUrl60") val atworkUrl60String: String,
-    @SerializedName("artworkUrl100") val atworkUrl100String: String,
-    @SerializedName("artworkUrl600") val atworkUrl600String: String
+    @SerializedName("collectionName") val name: String?,
+    @SerializedName("feedUrl") val feedUrlString: String?,
+    @SerializedName("artworkUrl30") val atworkUrl30String: String?,
+    @SerializedName("artworkUrl60") val atworkUrl60String: String?,
+    @SerializedName("artworkUrl100") val atworkUrl100String: String?,
+    @SerializedName("artworkUrl600") val atworkUrl600String: String?
 )

--- a/core/src/main/java/com/guardian/core/search/api/SearchItunesApiDataObject.kt
+++ b/core/src/main/java/com/guardian/core/search/api/SearchItunesApiDataObject.kt
@@ -7,5 +7,6 @@ data class SearchItunesApiDataObject (
     @SerializedName("feedUrl") val feedUrlString: String,
     @SerializedName("artworkUrl30") val atworkUrl30String: String,
     @SerializedName("artworkUrl60") val atworkUrl60String: String,
-    @SerializedName("artworkUrl100") val atworkUrl100String: String
+    @SerializedName("artworkUrl100") val atworkUrl100String: String,
+    @SerializedName("artworkUrl600") val atworkUrl600String: String
 )

--- a/core/src/main/java/com/guardian/core/search/api/SearchResultSetApiObject.kt
+++ b/core/src/main/java/com/guardian/core/search/api/SearchResultSetApiObject.kt
@@ -3,5 +3,5 @@ package com.guardian.core.search.api
 import com.google.gson.annotations.SerializedName
 
 data class SearchResultSetApiObject (
-    @SerializedName("results") val results: List<SearchItunesApiDataObject>
+    @SerializedName("results") val results: List<SearchItunesApiDataObject>?
 )


### PR DESCRIPTION
Simple set up with a list of items from the iTunes search api with a handy generic list adapter.

This PR only really contains some testing UI i used to verify that the Dagger set up i had done on master was working.

The work i had done prior was just to copy over files from UAMP into a separate module for later use (in the end i deicided it makes more sense for the medaBrowserService implementation to sit in the same module as my repositories). I also set up dagger to inject dependencies into the constructor methods of fragments and viewmodels using multibindings and factories passed to the fragment manager, and the viewModels delegate method which i basically copied from one of the google samples. So far it seems to have kept boilerplate in the views to a minimum.

I am also using the navigation library, data binding, coroutines, lifecycle and livedata because that seems to make life a lot easier too.